### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -82,7 +82,7 @@ jobs:
           echo "DOCKER_TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       -
         name: Build Docker image
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ env.DOCKER_IMAGE }}
           registry: ${{ env.DOCKER_REGISTRY }}
@@ -100,7 +100,7 @@ jobs:
 #          account_key: ${{ secrets.GCLOUD_KEY }}
 #      -
 #        name: Publish Docker image
-#        uses: elgohr/Publish-Docker-Github-Action@3.02
+#        uses: elgohr/Publish-Docker-Github-Action@v5
 #        with:
 #          name: ${{ env.DOCKER_IMAGE }}
 #          username: ${{ steps.gcloud.outputs.username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore